### PR TITLE
feat: equality between varbianry columns

### DIFF
--- a/crates/proof-of-sql-parser/src/intermediate_ast.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_ast.rs
@@ -345,6 +345,8 @@ pub enum Literal {
     Int128(i128),
     /// String Literal
     VarChar(String),
+    /// Binary Data Literal
+    VarBinary(Vec<u8>),
     /// Decimal Literal
     Decimal(BigDecimal),
     /// Timestamp Literal

--- a/crates/proof-of-sql-parser/src/sql.lalrpop
+++ b/crates/proof-of-sql-parser/src/sql.lalrpop
@@ -334,6 +334,8 @@ LiteralValue: Box<intermediate_ast::Literal> = {
     <value: BooleanLiteral> => Box::new(intermediate_ast::Literal::Boolean(value)),
 
     <value: StringLiteral> => Box::new(intermediate_ast::Literal::VarChar(<>)),
+    
+    <value: HexLiteral> => Box::new(intermediate_ast::Literal::VarBinary(<>)),
 
     <value: Int128UnaryNumericLiteral> => if <> <= i64::MAX.into() && <> >= i64::MIN.into() {
         Box::new(intermediate_ast::Literal::BigInt(<> as i64))
@@ -375,6 +377,24 @@ UInt64NumericLiteral: u64 = {
 
 pub StringLiteral: String = {
     STRING_LITERAL => <>[1..<>.len() - 1].replace("''", "'"),
+};
+
+pub HexLiteral: Vec<u8> = {
+    r"0x([0-9a-fA-F]{2})*" => {
+        let hex_str = &<>[2..]; // Skip the "0x" prefix
+        let mut bytes = Vec::with_capacity(hex_str.len() / 2);
+        
+        for i in (0..hex_str.len()).step_by(2) {
+            if i + 1 < hex_str.len() {
+                let byte_str = &hex_str[i..i+2];
+                if let Ok(byte) = u8::from_str_radix(byte_str, 16) {
+                    bytes.push(byte);
+                }
+            }
+        }
+        
+        bytes
+    },
 };
 
 pub BooleanLiteral: bool = {
@@ -454,6 +474,9 @@ match {
     ">" => ">",
     "<" => "<",
     ";" => ";",
+    
+    // Hex literal for VarBinary
+    r"0x([0-9a-fA-F]{2})*" => r"0x([0-9a-fA-F]{2})*",
 } else {
     r"[A-Za-z_][A-Za-z0-9_]*" => ID,
     // Decimal numbers with mandatory fractional part

--- a/crates/proof-of-sql-parser/src/sqlparser.rs
+++ b/crates/proof-of-sql-parser/src/sqlparser.rs
@@ -7,7 +7,12 @@ use crate::{
     },
     Identifier, ResourceId, SelectStatement,
 };
-use alloc::{boxed::Box, string::ToString, vec};
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+    vec,
+};
 use core::fmt::Display;
 use sqlparser::ast::{
     BinaryOperator, DataType, Expr, Function, FunctionArg, FunctionArgExpr, GroupByExpr, Ident,
@@ -66,6 +71,17 @@ impl From<Literal> for Expr {
     fn from(literal: Literal) -> Self {
         match literal {
             Literal::VarChar(s) => Expr::Value(Value::SingleQuotedString(s)),
+            Literal::VarBinary(bytes) => {
+                // Convert binary data to hex string for SQL representation
+                let hex_string =
+                    bytes
+                        .iter()
+                        .fold(String::with_capacity(bytes.len() * 2), |mut acc, byte| {
+                            acc.push_str(&format!("{byte:02x}"));
+                            acc
+                        });
+                Expr::Value(Value::HexStringLiteral(hex_string))
+            }
             Literal::BigInt(n) => Expr::Value(Value::Number(n.to_string(), false)),
             Literal::Int128(n) => Expr::Value(Value::Number(n.to_string(), false)),
             Literal::Decimal(n) => Expr::Value(Value::Number(n.to_string(), false)),

--- a/crates/proof-of-sql-planner/src/context.rs
+++ b/crates/proof-of-sql-planner/src/context.rs
@@ -103,13 +103,13 @@ impl<S: Scalar> ContextProvider for PoSqlContextProvider<'_, S> {
 }
 
 /// A [`TableSource`] implementation for Proof of SQL
-struct PoSqlTableSource {
+pub(crate) struct PoSqlTableSource {
     schema: SchemaRef,
 }
 
 impl PoSqlTableSource {
     /// Create a new `PoSqlTableSource`
-    fn new(column_fields: Vec<ColumnField>) -> Self {
+    pub(crate) fn new(column_fields: Vec<ColumnField>) -> Self {
         let arrow_schema = Schema::new(
             column_fields
                 .into_iter()

--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -1,7 +1,7 @@
 use arrow::datatypes::DataType;
 use datafusion::{
     common::DataFusionError,
-    logical_expr::{Expr, Operator},
+    logical_expr::{Expr, LogicalPlan, Operator},
 };
 use proof_of_sql::sql::parse::ConversionError;
 use snafu::Snafu;
@@ -28,6 +28,12 @@ pub enum PlannerError {
         /// Underlying datafusion error
         source: DataFusionError,
     },
+    /// Returned if a table is not found
+    #[snafu(display("Table not found: {}", table_name))]
+    TableNotFound {
+        /// Table name
+        table_name: String,
+    },
     /// Returned when a datatype is not supported
     #[snafu(display("Unsupported datatype: {}", data_type))]
     UnsupportedDataType {
@@ -45,6 +51,12 @@ pub enum PlannerError {
     UnsupportedLogicalExpression {
         /// Unsupported logical expression
         expr: Expr,
+    },
+    /// Returned when a `LogicalPlan` is not supported
+    #[snafu(display("LogicalPlan is not supported"))]
+    UnsupportedLogicalPlan {
+        /// Unsupported `LogicalPlan`
+        plan: LogicalPlan,
     },
     /// Returned when the `LogicalPlan` is not resolved
     #[snafu(display("LogicalPlan is not resolved"))]

--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -5,11 +5,15 @@ extern crate alloc;
 mod context;
 pub use context::PoSqlContextProvider;
 #[cfg(test)]
+pub(crate) use context::PoSqlTableSource;
+#[cfg(test)]
 mod df_util;
 mod expr;
 pub use expr::expr_to_proof_expr;
 mod error;
 pub use error::{PlannerError, PlannerResult};
+mod plan;
+pub use plan::logical_plan_to_proof_plan;
 mod util;
 pub(crate) use util::{
     column_fields_to_schema, column_to_column_ref, scalar_value_to_literal_value,

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -1,0 +1,461 @@
+use super::{expr_to_proof_expr, table_reference_to_table_ref, PlannerError, PlannerResult};
+use alloc::vec::Vec;
+use datafusion::{
+    common::DFSchema,
+    logical_expr::{Expr, LogicalPlan, TableScan},
+    sql::{sqlparser::ast::Ident, TableReference},
+};
+use indexmap::IndexMap;
+use proof_of_sql::{
+    base::database::{ColumnField, ColumnRef, ColumnType, TableRef},
+    sql::{
+        proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr, TableExpr},
+        proof_plans::DynProofPlan,
+    },
+};
+
+/// Get `AliasedDynProofExpr` from a `TableRef`, column indices for projection as well as
+/// input and output schemas
+///
+/// Note that at least in the current implementation of `DataFusion`
+/// the output schema should be a subset of the input schema
+/// and that no aliasing should take place.
+/// However that shouldn't be taken for granted.
+fn get_aliased_dyn_proof_exprs(
+    table_ref: &TableRef,
+    projection: &[usize],
+    input_schema: &DFSchema,
+    output_schema: &DFSchema,
+) -> PlannerResult<Vec<AliasedDynProofExpr>> {
+    projection
+        .iter()
+        .enumerate()
+        .map(
+            |(output_index, input_index)| -> PlannerResult<AliasedDynProofExpr> {
+                // Get output column name / alias
+                let alias: Ident = output_schema.field(output_index).name().as_str().into();
+                let input_column_name: Ident =
+                    input_schema.field(*input_index).name().as_str().into();
+                let data_type = input_schema.field(*input_index).data_type();
+                let expr = DynProofExpr::new_column(ColumnRef::new(
+                    table_ref.clone(),
+                    input_column_name,
+                    ColumnType::try_from(data_type.clone()).map_err(|_e| {
+                        PlannerError::UnsupportedDataType {
+                            data_type: data_type.clone(),
+                        }
+                    })?,
+                ));
+                Ok(AliasedDynProofExpr { expr, alias })
+            },
+        )
+        .collect::<PlannerResult<Vec<_>>>()
+}
+
+/// Convert a `TableScan` without filters or fetch limit to a `DynProofPlan`
+fn table_scan_to_projection(
+    table_name: &TableReference,
+    schemas: &IndexMap<TableReference, DFSchema>,
+    projection: &[usize],
+    projected_schema: &DFSchema,
+) -> PlannerResult<DynProofPlan> {
+    // Check if the table exists
+    let table_ref = table_reference_to_table_ref(table_name)?;
+    let input_schema = schemas
+        .get(table_name)
+        .ok_or_else(|| PlannerError::TableNotFound {
+            table_name: table_name.to_string(),
+        })?;
+    // Get aliased expressions
+    let aliased_dyn_proof_exprs =
+        get_aliased_dyn_proof_exprs(&table_ref, projection, input_schema, projected_schema)?;
+    let column_fields = aliased_dyn_proof_exprs
+        .iter()
+        .map(|aliased_expr| {
+            ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
+        })
+        .collect::<Vec<_>>();
+    let table_exec = DynProofPlan::new_table(table_ref, column_fields);
+    Ok(DynProofPlan::new_projection(
+        aliased_dyn_proof_exprs,
+        table_exec,
+    ))
+}
+
+/// Convert a `TableScan` with filters but without fetch limit to a `DynProofPlan`
+///
+/// # Panics
+/// Panics if there are no filters which should not happen if called from `logical_plan_to_proof_plan`
+fn table_scan_to_filter(
+    table_name: &TableReference,
+    schemas: &IndexMap<TableReference, DFSchema>,
+    projection: &[usize],
+    projected_schema: &DFSchema,
+    filters: &[Expr],
+) -> PlannerResult<DynProofPlan> {
+    // Check if the table exists
+    let table_ref = table_reference_to_table_ref(table_name)?;
+    let input_schema = schemas
+        .get(table_name)
+        .ok_or_else(|| PlannerError::TableNotFound {
+            table_name: table_name.to_string(),
+        })?;
+    // Get aliased expressions
+    let aliased_dyn_proof_exprs =
+        get_aliased_dyn_proof_exprs(&table_ref, projection, input_schema, projected_schema)?;
+    let table_expr = TableExpr { table_ref };
+    // Filter
+    let consolidated_filter_proof_expr = filters
+        .iter()
+        .map(|f| expr_to_proof_expr(f, input_schema))
+        .reduce(|a, b| Ok(DynProofExpr::try_new_and(a?, b?)?))
+        .expect("At least one filter expression is required")?;
+    Ok(DynProofPlan::new_filter(
+        aliased_dyn_proof_exprs,
+        table_expr,
+        consolidated_filter_proof_expr,
+    ))
+}
+
+/// Visit a [`datafusion::logical_plan::LogicalPlan`] and return a [`DynProofPlan`]
+pub fn logical_plan_to_proof_plan(
+    plan: &LogicalPlan,
+    schemas: &IndexMap<TableReference, DFSchema>,
+) -> PlannerResult<DynProofPlan> {
+    match plan {
+        LogicalPlan::EmptyRelation { .. } => Ok(DynProofPlan::new_empty()),
+        // `projection` shouldn't be None in analyzed and optimized plans
+        LogicalPlan::TableScan(TableScan {
+            table_name,
+            projection: Some(projection),
+            projected_schema,
+            filters,
+            fetch: None,
+            ..
+        }) => {
+            if filters.is_empty() {
+                table_scan_to_projection(table_name, schemas, projection, projected_schema)
+            } else {
+                table_scan_to_filter(table_name, schemas, projection, projected_schema, filters)
+            }
+        }
+        _ => Err(PlannerError::UnsupportedLogicalPlan { plan: plan.clone() }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{df_util::*, PoSqlTableSource};
+    use alloc::{sync::Arc, vec};
+    use arrow::datatypes::DataType;
+    use datafusion::logical_expr::{EmptyRelation, Prepare, TableScan, TableSource};
+    use indexmap::indexmap;
+
+    #[expect(non_snake_case)]
+    fn TABLE_REF_TABLE() -> TableRef {
+        TableRef::from_names(None, "table")
+    }
+
+    #[expect(non_snake_case)]
+    fn SCHEMAS() -> IndexMap<TableReference, DFSchema> {
+        indexmap! {
+            TableReference::from("table") => df_schema(
+                "table",
+                vec![
+                    ("a", DataType::Int64),
+                    ("b", DataType::Int32),
+                    ("c", DataType::Utf8),
+                    ("d", DataType::Boolean),
+                ],
+            ),
+        }
+    }
+
+    #[expect(non_snake_case)]
+    fn EMPTY_SCHEMAS() -> IndexMap<TableReference, DFSchema> {
+        indexmap! {}
+    }
+
+    #[expect(non_snake_case)]
+    fn TABLE_SOURCE() -> Arc<dyn TableSource> {
+        Arc::new(PoSqlTableSource::new(vec![
+            ColumnField::new("a".into(), ColumnType::BigInt),
+            ColumnField::new("b".into(), ColumnType::Int),
+            ColumnField::new("c".into(), ColumnType::VarChar),
+            ColumnField::new("d".into(), ColumnType::Boolean),
+        ]))
+    }
+
+    #[expect(non_snake_case)]
+    fn ALIASED_A() -> AliasedDynProofExpr {
+        AliasedDynProofExpr {
+            expr: DynProofExpr::new_column(ColumnRef::new(
+                TABLE_REF_TABLE(),
+                "a".into(),
+                ColumnType::BigInt,
+            )),
+            alias: "a".into(),
+        }
+    }
+
+    #[expect(non_snake_case)]
+    fn ALIASED_B() -> AliasedDynProofExpr {
+        AliasedDynProofExpr {
+            expr: DynProofExpr::new_column(ColumnRef::new(
+                TABLE_REF_TABLE(),
+                "b".into(),
+                ColumnType::Int,
+            )),
+            alias: "b".into(),
+        }
+    }
+
+    #[expect(non_snake_case)]
+    fn ALIASED_C() -> AliasedDynProofExpr {
+        AliasedDynProofExpr {
+            expr: DynProofExpr::new_column(ColumnRef::new(
+                TABLE_REF_TABLE(),
+                "c".into(),
+                ColumnType::VarChar,
+            )),
+            alias: "c".into(),
+        }
+    }
+
+    #[expect(non_snake_case)]
+    fn ALIASED_D() -> AliasedDynProofExpr {
+        AliasedDynProofExpr {
+            expr: DynProofExpr::new_column(ColumnRef::new(
+                TABLE_REF_TABLE(),
+                "d".into(),
+                ColumnType::Boolean,
+            )),
+            alias: "d".into(),
+        }
+    }
+
+    // get_aliased_dyn_proof_exprs
+    #[test]
+    fn we_can_get_aliased_proof_expr_with_specified_projection_columns() {
+        // Unused columns can be of unsupported types
+        let table_ref = TABLE_REF_TABLE();
+        let input_schema = df_schema(
+            "table",
+            vec![
+                ("a", DataType::Int64),
+                ("b", DataType::Int32),
+                ("c", DataType::Utf8),
+                ("d", DataType::Float32), // Unused column
+            ],
+        );
+        let output_schema = df_schema("table", vec![("b", DataType::Int32), ("c", DataType::Utf8)]);
+        let result =
+            get_aliased_dyn_proof_exprs(&table_ref, &[1, 2], &input_schema, &output_schema)
+                .unwrap();
+        let expected = vec![ALIASED_B(), ALIASED_C()];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_can_get_aliased_proof_expr_without_specified_projection_columns() {
+        let table_ref = TABLE_REF_TABLE();
+        let input_schema = df_schema(
+            "table",
+            vec![
+                ("a", DataType::Int64),
+                ("b", DataType::Int32),
+                ("c", DataType::Utf8),
+                ("d", DataType::Boolean),
+            ],
+        );
+        let output_schema = df_schema(
+            "table",
+            vec![
+                ("a", DataType::Int64),
+                ("b", DataType::Int32),
+                ("c", DataType::Utf8),
+                ("d", DataType::Boolean),
+            ],
+        );
+        let result =
+            get_aliased_dyn_proof_exprs(&table_ref, &[0, 1, 2, 3], &input_schema, &output_schema)
+                .unwrap();
+        let expected = vec![ALIASED_A(), ALIASED_B(), ALIASED_C(), ALIASED_D()];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_cannot_get_aliased_proof_expr_if_unsupported_data_types_are_included() {
+        let table_ref = TABLE_REF_TABLE();
+        let input_schema = df_schema(
+            "table",
+            vec![
+                ("a", DataType::Int64),
+                ("b", DataType::Float64),
+                ("c", DataType::Utf8),
+                ("d", DataType::Boolean),
+            ],
+        );
+        let output_schema = df_schema(
+            "table",
+            vec![
+                ("b", DataType::Float64),
+                ("c", DataType::Utf8),
+                ("d", DataType::Date32),
+            ],
+        );
+        assert!(matches!(
+            get_aliased_dyn_proof_exprs(&table_ref, &[1, 2, 3], &input_schema, &output_schema,),
+            Err(PlannerError::UnsupportedDataType { .. })
+        ));
+    }
+
+    // EmptyRelation
+    #[test]
+    fn we_can_convert_empty_plan_to_proof_plan() {
+        let empty_plan = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::new(DFSchema::empty()),
+        });
+        let schemas = indexmap! {};
+        let result = logical_plan_to_proof_plan(&empty_plan, &schemas).unwrap();
+        assert_eq!(result, DynProofPlan::new_empty());
+    }
+
+    // TableScan
+    #[test]
+    fn we_can_convert_table_scan_plan_to_proof_plan_without_filter_or_fetch_limit() {
+        let plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let schemas = SCHEMAS();
+        let result = logical_plan_to_proof_plan(&plan, &schemas).unwrap();
+        let expected = DynProofPlan::new_projection(
+            vec![ALIASED_A(), ALIASED_B(), ALIASED_C(), ALIASED_D()],
+            DynProofPlan::new_table(
+                TABLE_REF_TABLE(),
+                vec![
+                    ColumnField::new("a".into(), ColumnType::BigInt),
+                    ColumnField::new("b".into(), ColumnType::Int),
+                    ColumnField::new("c".into(), ColumnType::VarChar),
+                    ColumnField::new("d".into(), ColumnType::Boolean),
+                ],
+            ),
+        );
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_cannot_convert_table_scan_plan_to_proof_plan_without_filter_or_fetch_limit_if_bad_schemas(
+    ) {
+        let plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let schemas = EMPTY_SCHEMAS();
+        let result = logical_plan_to_proof_plan(&plan, &schemas);
+        assert!(matches!(result, Err(PlannerError::TableNotFound { .. })));
+    }
+
+    #[test]
+    fn we_can_convert_table_scan_plan_to_proof_plan_with_filter_but_without_fetch_limit() {
+        let filter_exprs = vec![
+            df_column("table", "a").eq(df_column("table", "b")),
+            df_column("table", "d"),
+        ];
+        let plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 2]),
+                filter_exprs,
+                None,
+            )
+            .unwrap(),
+        );
+        let schemas = SCHEMAS();
+        let result = logical_plan_to_proof_plan(&plan, &schemas).unwrap();
+        let expected = DynProofPlan::new_filter(
+            vec![ALIASED_A(), ALIASED_C()],
+            TableExpr {
+                table_ref: TABLE_REF_TABLE(),
+            },
+            DynProofExpr::try_new_and(
+                DynProofExpr::try_new_equals(
+                    DynProofExpr::new_column(ColumnRef::new(
+                        TABLE_REF_TABLE(),
+                        "a".into(),
+                        ColumnType::BigInt,
+                    )),
+                    DynProofExpr::new_column(ColumnRef::new(
+                        TABLE_REF_TABLE(),
+                        "b".into(),
+                        ColumnType::Int,
+                    )),
+                )
+                .unwrap(),
+                DynProofExpr::new_column(ColumnRef::new(
+                    TABLE_REF_TABLE(),
+                    "d".into(),
+                    ColumnType::Boolean,
+                )),
+            )
+            .unwrap(),
+        );
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_cannot_convert_table_scan_plan_to_proof_plan_with_filter_but_without_fetch_limit_if_bad_schemas(
+    ) {
+        let filter_exprs = vec![
+            df_column("table", "a").eq(df_column("table", "b")),
+            df_column("table", "d"),
+        ];
+        let plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 2]),
+                filter_exprs,
+                None,
+            )
+            .unwrap(),
+        );
+        let schemas = EMPTY_SCHEMAS();
+        let result = logical_plan_to_proof_plan(&plan, &schemas);
+        assert!(matches!(result, Err(PlannerError::TableNotFound { .. })));
+    }
+
+    // Unsupported
+    #[test]
+    fn we_cannot_convert_unsupported_logical_plan_to_proof_plan() {
+        let plan = LogicalPlan::Prepare(Prepare {
+            name: "not_a_real_plan".to_string(),
+            data_types: vec![],
+            input: Arc::new(LogicalPlan::EmptyRelation(EmptyRelation {
+                produce_one_row: false,
+                schema: Arc::new(DFSchema::empty()),
+            })),
+        });
+        let schemas = SCHEMAS();
+        assert!(matches!(
+            logical_plan_to_proof_plan(&plan, &schemas),
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
+    }
+}

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -30,6 +30,7 @@ pub(crate) fn scalar_value_to_literal_value(value: ScalarValue) -> PlannerResult
         ScalarValue::Int64(Some(v)) => Ok(LiteralValue::BigInt(v)),
         ScalarValue::UInt8(Some(v)) => Ok(LiteralValue::Uint8(v)),
         ScalarValue::Utf8(Some(v)) => Ok(LiteralValue::VarChar(v)),
+        ScalarValue::Binary(Some(v)) => Ok(LiteralValue::VarBinary(v)),
         ScalarValue::TimestampSecond(Some(v), None) => Ok(LiteralValue::TimeStampTZ(
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::utc(),
@@ -175,6 +176,13 @@ mod tests {
         assert_eq!(
             scalar_value_to_literal_value(value).unwrap(),
             LiteralValue::VarChar("value".to_string())
+        );
+
+        // Binary
+        let value = ScalarValue::Binary(Some(vec![72, 97, 108, 108, 101, 108, 117, 106, 97, 104]));
+        assert_eq!(
+            scalar_value_to_literal_value(value).unwrap(),
+            LiteralValue::VarBinary(vec![72, 97, 108, 108, 101, 108, 117, 106, 97, 104])
         );
 
         // TimestampSecond

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -54,6 +54,7 @@ impl ColumnCommitmentMetadata {
             | (
                 ColumnType::Boolean
                 | ColumnType::VarChar
+                | ColumnType::VarBinary
                 | ColumnType::Scalar
                 | ColumnType::Decimal75(..),
                 ColumnBounds::NoOrder,

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -148,6 +148,17 @@ impl<'a, S: Scalar> Column<'a, S> {
                 alloc.alloc_slice_fill_with(length, |_| alloc.alloc_str(string) as &str),
                 alloc.alloc_slice_fill_copy(length, S::from(string)),
             )),
+            LiteralValue::VarBinary(bytes) => {
+                // Convert the bytes to a slice of bytes references
+                let bytes_slice = alloc
+                    .alloc_slice_fill_with(length, |_| alloc.alloc_slice_copy(bytes) as &[_]);
+
+                // Convert the bytes to scalars using from_byte_slice_via_hash
+                let scalars =
+                    alloc.alloc_slice_fill_copy(length, S::from_byte_slice_via_hash(bytes));
+
+                Column::VarBinary((bytes_slice, scalars))
+            }
         }
     }
 

--- a/crates/proof-of-sql/src/base/database/expression_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation.rs
@@ -55,6 +55,7 @@ impl<S: Scalar> OwnedTable<S> {
                 Ok(OwnedColumn::Decimal75(precision, scale, vec![scalar; len]))
             }
             Literal::VarChar(s) => Ok(OwnedColumn::VarChar(vec![s.clone(); len])),
+            Literal::VarBinary(bytes) => Ok(OwnedColumn::VarBinary(vec![bytes.clone(); len])),
             Literal::Timestamp(its) => Ok(OwnedColumn::TimestampTZ(
                 its.timeunit(),
                 its.timezone(),

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -201,8 +201,11 @@ pub(crate) fn max_aggregate_column_by_index_counts<'a, S: Scalar>(
             max_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
         Column::Scalar(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::VarBinary(_) => {
+            unreachable!("MAX can not be applied to varbinary")
+        }
         // The following should never be reached because the `MAX` function can't be applied to varchar.
-        Column::VarChar(_) | Column::VarBinary(_) => {
+        Column::VarChar(_) => {
             unreachable!("MAX can not be applied to varchar")
         }
     }
@@ -235,7 +238,7 @@ pub(crate) fn min_aggregate_column_by_index_counts<'a, S: Scalar>(
             min_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
         Column::Scalar(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::VarBinary(_) => unreachable!("MIN can not be applied to varchar"),
+        Column::VarBinary(_) => unreachable!("MIN can not be applied to varbinary"),
         // The following should never be reached because the `MIN` function can't be applied to varchar.
         Column::VarChar(_) => {
             unreachable!("MIN can not be applied to varchar")

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -8,6 +8,46 @@ use crate::{
 use bumpalo::Bump;
 
 #[test]
+#[should_panic(expected = "MAX can not be applied to varbinary")]
+fn we_cannot_apply_max_to_varbinary() {
+    let col: Column<'_, TestScalar> = Column::VarBinary((&[], &[]));
+    let indexes = &[];
+    let counts = &[];
+    let alloc = bumpalo::Bump::new();
+    let _ = max_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
+#[should_panic(expected = "MIN can not be applied to varbinary")]
+fn we_cannot_apply_min_to_varbinary() {
+    let col: Column<'_, TestScalar> = Column::VarBinary((&[], &[]));
+    let indexes = &[];
+    let counts = &[];
+    let alloc = bumpalo::Bump::new();
+    let _ = min_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
+#[should_panic(expected = "MAX can not be applied to varchar")]
+fn we_cannot_apply_max_to_varchar() {
+    let col: Column<'_, TestScalar> = Column::VarChar((&[], &[]));
+    let indexes = &[];
+    let counts = &[];
+    let alloc = bumpalo::Bump::new();
+    let _ = max_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
+#[should_panic(expected = "MIN can not be applied to varchar")]
+fn we_cannot_apply_min_to_varchar() {
+    let col: Column<'_, TestScalar> = Column::VarChar((&[], &[]));
+    let indexes = &[];
+    let counts = &[];
+    let alloc = bumpalo::Bump::new();
+    let _ = min_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
 fn we_can_aggregate_empty_columns() {
     let column_a = Column::BigInt::<TestScalar>(&[]);
     let column_b = Column::VarChar((&[], &[]));

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -1,9 +1,9 @@
 use crate::base::{
     database::ColumnType,
     math::{decimal::Precision, i256::I256},
-    scalar::Scalar,
+    scalar::{Scalar, ScalarExt},
 };
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 use serde::{Deserialize, Serialize};
 
@@ -32,6 +32,9 @@ pub enum LiteralValue {
     ///  - the first element maps to the str value.
     ///  - the second element maps to the str hash (see [`crate::base::scalar::Scalar`]).
     VarChar(String),
+    /// Binary data literals
+    ///  - the backing store is a Vec<u8> for variable length binary data
+    VarBinary(Vec<u8>),
     /// i128 literals
     Int128(i128),
     /// Decimal literals with a max width of 252 bits
@@ -56,6 +59,7 @@ impl LiteralValue {
             Self::Int(_) => ColumnType::Int,
             Self::BigInt(_) => ColumnType::BigInt,
             Self::VarChar(_) => ColumnType::VarChar,
+            Self::VarBinary(_) => ColumnType::VarBinary,
             Self::Int128(_) => ColumnType::Int128,
             Self::Scalar(_) => ColumnType::Scalar,
             Self::Decimal75(precision, scale, _) => ColumnType::Decimal75(*precision, *scale),
@@ -73,6 +77,7 @@ impl LiteralValue {
             Self::Int(i) => i.into(),
             Self::BigInt(i) => i.into(),
             Self::VarChar(str) => str.into(),
+            Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
             Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),
             Self::Scalar(limbs) => (*limbs).into(),

--- a/crates/proof-of-sql/src/base/slice_ops/mod.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mod.rs
@@ -4,7 +4,7 @@
 //! Instead, it will simply truncate the longer one, which is equivalent to multiply each extra element by zero before summing.
 
 #[cfg(any(feature = "rayon", test))]
-pub const MIN_RAYON_LEN: usize = 1 << 8;
+pub const MIN_RAYON_LEN: usize = 1 << 12;
 
 mod add_const;
 #[cfg(test)]

--- a/crates/proof-of-sql/src/base/slice_ops/mod.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mod.rs
@@ -4,7 +4,7 @@
 //! Instead, it will simply truncate the longer one, which is equivalent to multiply each extra element by zero before summing.
 
 #[cfg(any(feature = "rayon", test))]
-pub const MIN_RAYON_LEN: usize = 1 << 16;
+pub const MIN_RAYON_LEN: usize = 1 << 28;
 
 mod add_const;
 #[cfg(test)]

--- a/crates/proof-of-sql/src/base/slice_ops/mod.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mod.rs
@@ -4,7 +4,7 @@
 //! Instead, it will simply truncate the longer one, which is equivalent to multiply each extra element by zero before summing.
 
 #[cfg(any(feature = "rayon", test))]
-pub const MIN_RAYON_LEN: usize = 1 << 12;
+pub const MIN_RAYON_LEN: usize = 1 << 16;
 
 mod add_const;
 #[cfg(test)]

--- a/crates/proof-of-sql/src/base/slice_ops/mod.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mod.rs
@@ -4,7 +4,7 @@
 //! Instead, it will simply truncate the longer one, which is equivalent to multiply each extra element by zero before summing.
 
 #[cfg(any(feature = "rayon", test))]
-pub const MIN_RAYON_LEN: usize = 1 << 28;
+pub const MIN_RAYON_LEN: usize = 1 << 24;
 
 mod add_const;
 #[cfg(test)]

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -87,6 +87,9 @@ impl DynProofExprBuilder<'_> {
             Literal::Boolean(b) => Ok(DynProofExpr::new_literal(LiteralValue::Boolean(*b))),
             Literal::BigInt(i) => Ok(DynProofExpr::new_literal(LiteralValue::BigInt(*i))),
             Literal::Int128(i) => Ok(DynProofExpr::new_literal(LiteralValue::Int128(*i))),
+            Literal::VarBinary(bytes) => Ok(DynProofExpr::new_literal(LiteralValue::VarBinary(
+                bytes.clone(),
+            ))),
             Literal::Decimal(d) => {
                 let raw_scale = d.scale();
                 let scale = raw_scale.try_into().map_err(|_| InvalidScale {

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -348,6 +348,7 @@ pub(crate) fn type_check_binary_operation(
             matches!(
                 (left_dtype, right_dtype),
                 (ColumnType::VarChar, ColumnType::VarChar)
+                    | (ColumnType::VarBinary, ColumnType::VarBinary)
                     | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
                     | (ColumnType::Boolean, ColumnType::Boolean)
                     | (_, ColumnType::Scalar)

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -288,6 +288,7 @@ impl QueryContextBuilder<'_> {
             Literal::BigInt(_) => Ok(ColumnType::BigInt),
             Literal::Int128(_) => Ok(ColumnType::Int128),
             Literal::VarChar(_) => Ok(ColumnType::VarChar),
+            Literal::VarBinary(_) => Ok(ColumnType::VarBinary),
             Literal::Decimal(d) => {
                 let precision = Precision::try_from(d.precision())?;
                 let scale = d.scale();

--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
@@ -5,6 +5,8 @@ use sqlparser::ast::Ident;
 /// A `DynProofExpr` with an alias.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AliasedDynProofExpr {
+    /// The `DynProofExpr` to alias.
     pub expr: DynProofExpr,
+    /// The alias for the expression.
     pub alias: Ident,
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -430,3 +430,33 @@ fn we_can_compute_the_correct_output_of_an_equals_expr_using_result_evaluate() {
     let expected_res = Column::Boolean(&[true, false, true, false]);
     assert_eq!(res, expected_res);
 }
+
+#[test]
+fn we_can_query_with_varbinary_equality() {
+    // Create a table with bigint and varbinary columns
+    let data: OwnedTable<Curve25519Scalar> = owned_table([
+        bigint("a", [123, 4567]),
+        varbinary("b", [[1, 2, 3].as_slice(), &[4, 5, 6, 7]]),
+    ]);
+
+    // Create table reference and accessor
+    let t = TableRef::new("sxt", "table");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+
+    // Build query plan: SELECT a, b FROM table WHERE b = [4,5,6,7]
+    let ast = filter(
+        cols_expr_plan(&t, &["a", "b"], &accessor),
+        tab(&t),
+        equal(column(&t, "b", &accessor), const_varbinary(&[4, 5, 6, 7])),
+    );
+
+    // Execute and verify query
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+
+    // Expected result: only the second row should be returned
+    let expected_res = owned_table([bigint("a", [4567]), varbinary("b", [&[4, 5, 6, 7]])]);
+
+    assert_eq!(res, expected_res);
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -1,11 +1,11 @@
 //! This module proves provable expressions.
 mod proof_expr;
-pub(crate) use proof_expr::ProofExpr;
+pub use proof_expr::ProofExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod proof_expr_test;
 
 mod aliased_dyn_proof_expr;
-pub(crate) use aliased_dyn_proof_expr::AliasedDynProofExpr;
+pub use aliased_dyn_proof_expr::AliasedDynProofExpr;
 
 mod add_subtract_expr;
 pub(crate) use add_subtract_expr::AddSubtractExpr;
@@ -62,7 +62,7 @@ pub(crate) use equals_expr::EqualsExpr;
 mod equals_expr_test;
 
 mod table_expr;
-pub(crate) use table_expr::TableExpr;
+pub use table_expr::TableExpr;
 
 #[cfg(test)]
 pub(crate) mod test_utility;

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -4,5 +4,6 @@ use serde::{Deserialize, Serialize};
 /// Expression for an SQL table
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct TableExpr {
+    /// The `TableRef` for the table
     pub table_ref: TableRef,
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -109,6 +109,11 @@ pub fn const_varchar(val: &str) -> DynProofExpr {
     DynProofExpr::new_literal(LiteralValue::VarChar(val.to_string()))
 }
 
+/// Creates a new `DynProofExpr::Literal` expression for a varbinary value.
+pub fn const_varbinary(val: &[u8]) -> DynProofExpr {
+    DynProofExpr::new_literal(LiteralValue::VarBinary(val.to_vec()))
+}
+
 /// Create a constant scalar value. Used if we don't want to specify column types.
 pub fn const_scalar<S: Scalar, T: Into<S>>(val: T) -> DynProofExpr {
     DynProofExpr::new_literal(LiteralValue::Scalar(val.into().into()))

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -793,6 +793,36 @@ fn we_can_prove_a_basic_group_by_query_with_dory() {
     assert_eq!(owned_table_result, expected_result);
 }
 
+#[test]
+#[cfg(feature = "blitzar")]
+fn we_can_prove_a_varbinary_equality_query_with_hex_literal() {
+    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(
+        TableRef::new("sxt", "table"),
+        owned_table([
+            bigint("a", [123, 4567]),
+            varbinary("b", [vec![1, 2, 3], vec![4, 5, 6, 7]]),
+        ]),
+        0,
+    );
+    let query = QueryExpr::try_new(
+        "SELECT a, b FROM table WHERE b = 0x04050607"
+            .parse()
+            .unwrap(),
+        "sxt".into(),
+        &accessor,
+    )
+    .unwrap();
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
+        .unwrap()
+        .table;
+    let expected_result = owned_table([bigint("a", [4567]), varbinary("b", [vec![4, 5, 6, 7]])]);
+    assert_eq!(owned_table_result, expected_result);
+}
+
 // Overflow checks
 #[test]
 #[cfg(feature = "blitzar")]

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -879,3 +879,276 @@ fn we_can_perform_arithmetic_and_conditional_operations_on_tinyint() {
     let expected_result = owned_table([tinyint("result", [9_i8, 10])]);
     assert_eq!(owned_table_result, expected_result);
 }
+
+#[test]
+#[cfg(feature = "blitzar")]
+fn we_can_perform_equality_checks_on_var_binary() {
+    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(
+        TableRef::new("sxt", "table"),
+        owned_table([
+            varbinary("a", [vec![], vec![], vec![], vec![]]),
+            varbinary("b", [vec![], vec![], vec![], vec![]]),
+            varbinary("c", [vec![], vec![], vec![], vec![]]),
+            varbinary("d", [vec![], vec![], vec![], vec![]]),
+            varbinary("e", [vec![], vec![], vec![], vec![]]),
+        ]),
+        0,
+    );
+    let query = QueryExpr::try_new(
+        "SELECT * FROM table WHERE a=b".parse().unwrap(),
+        "sxt".into(),
+        &accessor,
+    )
+    .unwrap();
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
+        .unwrap()
+        .table;
+    let expected_result = owned_table([
+        varbinary("a", [vec![], vec![], vec![], vec![]]),
+        varbinary("b", [vec![], vec![], vec![], vec![]]),
+        varbinary("c", [vec![], vec![], vec![], vec![]]),
+        varbinary("d", [vec![], vec![], vec![], vec![]]),
+        varbinary("e", [vec![], vec![], vec![], vec![]]),
+    ]);
+    assert_eq!(owned_table_result, expected_result);
+}
+
+#[test]
+#[cfg(feature = "blitzar")]
+#[allow(clippy::too_many_lines)]
+fn we_can_perform_rich_equality_checks_on_var_binary() {
+    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(
+        TableRef::new("sxt", "table"),
+        owned_table([
+            varbinary(
+                "a",
+                [
+                    vec![],
+                    b"\x01\x02\x03\x04\x05".to_vec(),
+                    vec![0xFF; 31],
+                    vec![0xAA, 0xBB],
+                ],
+            ),
+            varbinary(
+                "b",
+                [
+                    vec![],
+                    b"\x01\x02\x03\x04\x05".to_vec(),
+                    vec![0xFF; 31],
+                    vec![0xAA, 0xBB],
+                ],
+            ),
+            varbinary(
+                "c",
+                [
+                    b"\xDE\xAD\xBE\xEF".to_vec(),
+                    vec![],
+                    vec![0xFF; 31],
+                    b"\x01\x02\x03".to_vec(),
+                ],
+            ),
+            varbinary(
+                "d",
+                [
+                    vec![],
+                    b"\xAB\xCD".to_vec(),
+                    vec![0xEE; 31],
+                    b"\xFE".to_vec(),
+                ],
+            ),
+            varbinary(
+                "e",
+                [
+                    b"\xAA".to_vec(),
+                    b"\xAA\xBB\xCC".to_vec(),
+                    vec![0xDD; 31],
+                    vec![],
+                ],
+            ),
+        ]),
+        0,
+    );
+    let query = QueryExpr::try_new(
+        "SELECT * FROM table WHERE a=b".parse().unwrap(),
+        "sxt".into(),
+        &accessor,
+    )
+    .unwrap();
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
+        .unwrap()
+        .table;
+    let expected_result = owned_table([
+        varbinary(
+            "a",
+            [
+                vec![],
+                b"\x01\x02\x03\x04\x05".to_vec(),
+                vec![0xFF; 31],
+                vec![0xAA, 0xBB],
+            ],
+        ),
+        varbinary(
+            "b",
+            [
+                vec![],
+                b"\x01\x02\x03\x04\x05".to_vec(),
+                vec![0xFF; 31],
+                vec![0xAA, 0xBB],
+            ],
+        ),
+        varbinary(
+            "c",
+            [
+                b"\xDE\xAD\xBE\xEF".to_vec(),
+                vec![],
+                vec![0xFF; 31],
+                b"\x01\x02\x03".to_vec(),
+            ],
+        ),
+        varbinary(
+            "d",
+            [
+                vec![],
+                b"\xAB\xCD".to_vec(),
+                vec![0xEE; 31],
+                b"\xFE".to_vec(),
+            ],
+        ),
+        varbinary(
+            "e",
+            [
+                b"\xAA".to_vec(),
+                b"\xAA\xBB\xCC".to_vec(),
+                vec![0xDD; 31],
+                vec![],
+            ],
+        ),
+    ]);
+    assert_eq!(owned_table_result, expected_result);
+}
+
+#[test]
+#[cfg(feature = "blitzar")]
+#[allow(clippy::too_many_lines)]
+fn we_can_perform_equality_checks_on_rich_var_binary_data() {
+    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    // We'll create multiple columns to have richer data,
+    // including some rows where a != b.
+    // Only rows where a = b will appear in the final result.
+    accessor.add_table(
+        TableRef::new("sxt", "table"),
+        owned_table([
+            varbinary(
+                "a",
+                [
+                    vec![],           // row1
+                    vec![0x10, 0x11], // row2
+                    vec![0xAB, 0xCD], // row3
+                    vec![0x12],       // row4
+                    vec![0x34],       // row5
+                    vec![1, 2, 3],    // row6
+                ],
+            ),
+            varbinary(
+                "b",
+                [
+                    vec![],           // row1
+                    vec![0x11],       // row2
+                    vec![0xAB, 0xCD], // row3
+                    vec![0x12],       // row4
+                    vec![0x34],       // row5
+                    vec![1, 2, 3],    // row6
+                ],
+            ),
+            varbinary(
+                "c",
+                [
+                    vec![0x00; 31],   // row1
+                    vec![0x22],       // row2
+                    vec![],           // row3
+                    vec![0x98, 0x99], // row4
+                    vec![0x56],       // row5
+                    vec![4, 5],       // row6
+                ],
+            ),
+            varbinary(
+                "d",
+                [
+                    vec![0x00; 31],   // row1
+                    vec![0x22],       // row2
+                    vec![0x00],       // row3
+                    vec![0x98, 0x99], // row4
+                    vec![0x56],       // row5
+                    vec![4, 5],       // row6
+                ],
+            ),
+            varbinary(
+                "e",
+                [
+                    vec![0xFF, 0x00], // row1
+                    vec![0x33],       // row2
+                    vec![0xDD; 31],   // row3
+                    vec![0xFF; 31],   // row4
+                    vec![0x78],       // row5
+                    vec![6, 7],       // row6
+                ],
+            ),
+            varbinary(
+                "f",
+                [
+                    vec![0xFF, 0x00], // row1
+                    vec![0x33],       // row2
+                    vec![0xDD; 31],   // row3
+                    vec![0xFF; 31],   // row4
+                    vec![0x78],       // row5
+                    vec![6, 7, 8],    // row6
+                ],
+            ),
+            varbinary(
+                "g",
+                [
+                    vec![0xA1], // row1
+                    vec![0xA2], // row2
+                    vec![0xA3], // row3
+                    vec![0xA4], // row4
+                    vec![0xA5], // row5
+                    vec![0xA6], // row6
+                ],
+            ),
+        ]),
+        0,
+    );
+    let query = QueryExpr::try_new(
+        "SELECT * FROM table WHERE a=b AND c=d AND e=f"
+            .parse()
+            .unwrap(),
+        "sxt".into(),
+        &accessor,
+    )
+    .unwrap();
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
+        .unwrap()
+        .table;
+
+    let expected_result = owned_table([
+        varbinary("a", [vec![], vec![0x12], vec![0x34]]),
+        varbinary("b", [vec![], vec![0x12], vec![0x34]]),
+        varbinary("c", [vec![0x00; 31], vec![0x98, 0x99], vec![0x56]]),
+        varbinary("d", [vec![0x00; 31], vec![0x98, 0x99], vec![0x56]]),
+        varbinary("e", [vec![0xFF, 0x00], vec![0xFF; 31], vec![0x78]]),
+        varbinary("f", [vec![0xFF, 0x00], vec![0xFF; 31], vec![0x78]]),
+        varbinary("g", [vec![0xA1], vec![0xA4], vec![0xA5]]),
+    ]);
+    assert_eq!(owned_table_result, expected_result);
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
