### PR TITLE
Adding Null Support to Tables and Arrow

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -5,7 +5,7 @@ mod accessor;
 pub use accessor::{CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAccessor};
 
 mod column;
-pub use column::{Column, ColumnField, ColumnRef, ColumnType};
+pub use column::{Column, ColumnField, ColumnRef, ColumnType, NullableColumn};
 
 #[allow(dead_code)]
 pub(crate) mod slice_operation;
@@ -56,7 +56,7 @@ pub use table_ref::TableRef;
 pub mod arrow_schema_utility;
 
 mod owned_column;
-pub use owned_column::OwnedColumn;
+pub use owned_column::{OwnedColumn, OwnedNullableColumn};
 
 mod owned_column_error;
 pub(crate) use owned_column_error::ColumnCoercionError;


### PR DESCRIPTION
# Rationale for this change

This will be part of the first PR for the chain of PRs to solve

# What changes are included in this PR?

* feat: Add nullable column support for owned and borrowed columns

This commit introduces nullable column types for both owned and borrowed columns, providing a flexible way to handle NULL values in the database column representation. The implementation includes:

- `NullableColumn` for borrowed columns with optional presence slice
- `OwnedNullableColumn` for owned columns with optional presence vector
- Methods to create, check, and manipulate nullable columns
- Conversion methods between owned and borrowed nullable columns
- Comprehensive test coverage for the new nullable column functionality

* feat: Add scalar retrieval and creation methods for OwnedNullableColumn

Extends the OwnedNullableColumn with new methods to:
- Retrieve scalar values at specific indices with `scalar_at()` and `get_scalar_at()`
- Create nullable columns from optional scalars using `try_from_option_scalars()`
- Collect optional scalars into nullable columns with `try_collect_option_scalars()`

The new methods support various scalar types and handle NULL values flexibly, with comprehensive test coverage.

* feat: Add nullable expression evaluation support

Extends the expression evaluation system to handle nullable columns and NULL values:

- Introduced `evaluate_nullable()` method in `OwnedTable` to support expressions that may produce NULL values
- Updated binary and unary expression evaluation to work with nullable columns
- Added null propagation logic for various operations like AND, OR, arithmetic, and comparison
- Implemented comprehensive test cases for nullable expression evaluation
- Ensured consistent handling of NULL values across different column types and operations

* feat: Add Arrow ArrayRef to NullableColumn conversion support

Extends the Arrow array conversion system to handle nullable columns with null values:

- Implemented `to_nullable_column()` method in `ArrayRefExt` trait to convert Arrow arrays with null values
- Added comprehensive null handling for various Arrow data types
- Supported conversion of arrays with nulls to `NullableColumn` with default values for null positions
- Included test cases to verify nullable column conversion for different data types
- Ensured consistent handling of null values during Arrow array to column conversion

# Are these changes tested?

Yes, both in my own repo and locally as well, I also added several unit tests for the changes I made to demonstrate the correctness of the changes.
